### PR TITLE
Set the sequence id when sending using default metadata

### DIFF
--- a/src/DotPulsar/Internal/ProducerStream.cs
+++ b/src/DotPulsar/Internal/ProducerStream.cs
@@ -42,7 +42,11 @@ namespace DotPulsar.Internal
             }
         }
 
-        public async Task<CommandSendReceipt> Send(ReadOnlySequence<byte> payload) => await Send(_cachedMetadata, payload);
+        public Task<CommandSendReceipt> Send(ReadOnlySequence<byte> payload)
+        {
+            _cachedMetadata.SequenceId = _sequenceId.Current;
+            return Send(_cachedMetadata, payload);
+        }
 
         public async Task<CommandSendReceipt> Send(PulsarApi.MessageMetadata metadata, ReadOnlySequence<byte> payload)
         {


### PR DESCRIPTION
To prevent default sends to stop working after two sends, set the cached metadata's sequence id