### PR TITLE
Improve asynchronous calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,5 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+FodyWeavers.xsd

--- a/src/DotPulsar/DotPulsar.csproj
+++ b/src/DotPulsar/DotPulsar.csproj
@@ -21,7 +21,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All"/>
+    <PackageReference Include="ConfigureAwait.Fody" Version="3.2.0" PrivateAssets="All"/>
+    <PackageReference Include="Fody" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />
     <PackageReference Include="System.IO.Pipelines" Version="4.6.0" />
   </ItemGroup>

--- a/src/DotPulsar/FodyWeavers.xml
+++ b/src/DotPulsar/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <ConfigureAwait ContinueOnCapturedContext="false" />
+</Weavers>


### PR DESCRIPTION
Following advise we always follow in libraries:. There's probably a couple more places where there's an explicit async/await where it can be avoided, as for example:
` public async Task Send(CommandPing command) => await Send(command.AsBaseCommand());`
can become
` public Task Send(CommandPing command) => Send(command.AsBaseCommand());`
- https://blog.stephencleary.com/2012/02/async-and-await.html
- https://medium.com/bynder-tech/c-why-you-should-use-configureawait-false-in-your-library-code-d7837dce3d7f
- https://stackoverflow.com/questions/13489065/best-practice-to-call-configureawait-for-all-server-side-code
- https://msdn.microsoft.com/en-us/magazine/gg598924.aspx
